### PR TITLE
FaceAuth: 사진이 안찍히는 문제점 해결 : Skip Frame 추가

### DIFF
--- a/FaceAuth.py
+++ b/FaceAuth.py
@@ -7,7 +7,7 @@ class FaceAuth:
         CF.Key.set(key);
 
     def takePicture(self):
-        os.system('fswebcam  -i 0 -d v4l2:/dev/video0  --jpeg 95 --save alldoor.jpg -r 640x480')
+        os.system('fswebcam  -i 0 -d v4l2:/dev/video0  --jpeg 95 --save alldoor.jpg -r 640x480 -S 30')
         try:
             id = self.getFaceId('./alldoor.jpg')
             os.system('rm -f ./alldoor.jpg')


### PR DESCRIPTION
- https://www.raspberrypi.org/forums/viewtopic.php?f=45&t=60076

`
above fswebcam -p YUYV and fswebcam -S 3 kind of worked for initial question, error went away but had saturated (white) picture. Increasing the -S solved the saturation problem, finally using: fswebcam -d /dev/video0 -S 30 -F 5 tst.jpg
`
- http://raspberrypi.stackexchange.com/questions/29283/why-is-my-webcam-image-all-black
